### PR TITLE
Feature Bluemix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 pom.xml.versionsBackup
+/target/

--- a/build.xml
+++ b/build.xml
@@ -10,13 +10,12 @@
          defaultvalue="javaee7-web-min" />
   <property name="newVersion" value="0.12-SNAPSHOT" />
   <property environment="env" />
-  <property name="workdir" value="${basedir}/${artifactId}/target" />
+  <property name="workdir" value="${basedir}/target" />
   <property name="archresdir"
-            value="${workdir}/generated-sources/archetype/src"
+            value="${artifactId}/target/generated-sources/archetype/src"
             description="「mvn archetye:create-from-project」コマンドで作成された、アーキタイプとして格納される資源のディレクトリ" />
-  <property name="newarchdir" value="${workdir}/newarch" description="新しいアーキタイプを作成するディレクトリ" />
+  <property name="newarchdir" value="${workdir}/${artifactId}/newarch" description="新しいアーキタイプを作成するディレクトリ" />
   <property name="resdir" value="${newarchdir}/src" />
-  <property name="testArtifactId" value="${artifactId}-test" />
   <property name="db" value="derby" />
 
   <condition property="mvn.cmd" value="${env.MAVEN_HOME}/bin/mvn.cmd" else="/usr/local/bin/mvn">
@@ -116,6 +115,18 @@
 
   <target name="04_acceptance-test">
 
+    <antcall target="test-site"/>
+    <antcall target="test-glassfish"/>
+    <antcall target="test-was-liberty"/>
+    <antcall target="test-wildfly"/>
+
+  </target>
+  
+  
+  <target name="archetype-generate">
+    
+    <delete dir="${workdir}/${testArtifactId}"/>
+    
     <exec executable="${mvn.cmd}" dir="${workdir}" failonerror="true">
       <env key="JAVA_HOME" value="${java.home}" />
       <arg value="-DarchetypeGroupId=org.sitoolkit.ad.archetype" />
@@ -129,47 +140,83 @@
       <arg value="archetype:generate" />
     </exec>
 
-    <exec executable="${mvn.cmd}" dir="${workdir}/${testArtifactId}" failonerror="true">
-      <env key="JAVA_HOME" value="${java.home}" />
-      <arg value="-Pdb-migrate,${db}" />
-      <arg value="-Dfile.encoding=UTF-8" />
-      <arg value="-Das.port=8082" />
-      <arg value="compile" />
-    </exec>
+  </target>
+
+  
+  <target name="test-site">
+
+    <property name="testArtifactId" value="${artifactId}-test-site"/>
+    <antcall target="archetype-generate"/>    
 
     <exec executable="${mvn.cmd}" dir="${workdir}/${testArtifactId}" failonerror="true">
       <env key="JAVA_HOME" value="${java.home}" />
       <arg value="-Dfile.encoding=UTF-8" />
-      <arg value="-Das.port=8082" />
-      <arg value="-P${db}" />
+      <arg value="-Ddb.port=1528" />
+      <arg value="-P${db},db-migrate" />
       <arg value="site" />
     </exec>
 
-    <exec executable="${mvn.cmd}" dir="${workdir}/${testArtifactId}" failonerror="true">
-      <env key="JAVA_HOME" value="${java.home}" />
-      <arg value="-P${db},was-liberty,it" />
-      <arg value="-Dmaven.test.skip=false" />
-      <arg value="-Devidence.open=false" />
-      <arg value="-Dfile.encoding=UTF-8" />
-      <arg value="-Das.port=8082" />
-      <arg value="verify" />
-    </exec>
+  </target>
 
+
+  <target name="test-glassfish">
+  
+    <property name="testArtifactId" value="${artifactId}-test-glassfish"/>
+    <antcall target="archetype-generate"/>    
+  
     <exec executable="${mvn.cmd}"
           dir="${workdir}/${testArtifactId}"
           failonerror="true"
           if:set="glassfish">
       <env key="JAVA_HOME" value="${java.home}" />
-      <arg value="-P${db},embedded-glassfish,it" />
-      <arg value="-Dmaven.test.skip=false" />
+      <arg value="-P${db},db-migrate,embedded-glassfish,it" />
       <arg value="-Devidence.open=false" />
       <arg value="-Dfile.encoding=UTF-8" />
+      <arg value="-Ddb.port=1528" />
       <arg value="-Das.port=8081" />
+      <arg value="verify" />
+    </exec>
+    
+  </target>
+  
+  
+  <target name="test-was-liberty">
+    
+    <property name="testArtifactId" value="${artifactId}-test-was-liberty"/>
+    <antcall target="archetype-generate"/>    
+
+    <exec executable="${mvn.cmd}" dir="${workdir}/${testArtifactId}" failonerror="true">
+      <env key="JAVA_HOME" value="${java.home}" />
+      <arg value="-P${db},db-migrate,was-liberty,it" />
+      <arg value="-Devidence.open=false" />
+      <arg value="-Dfile.encoding=UTF-8" />
+      <arg value="-Ddb.port=1529" />
+      <arg value="-Das.port=8082" />
       <arg value="verify" />
     </exec>
 
   </target>
 
+  
+  <target name="test-wildfly">
+
+    <property name="testArtifactId" value="${artifactId}-test-wildfly"/>
+    <antcall target="archetype-generate"/>    
+
+    <exec executable="${mvn.cmd}" dir="${workdir}/${testArtifactId}" failonerror="true">
+      <env key="JAVA_HOME" value="${java.home}" />
+      <env key="JBOSS_HOME" value="${workdir}/${testArtifactId}/target/wildfly-run/wildfly-10.0.0.Final" />
+      <arg value="-P${db},db-migrate,wildfly,it" />
+      <arg value="-Dmaven.test.skip=false" />
+      <arg value="-Devidence.open=false" />
+      <arg value="-Dfile.encoding=UTF-8" />
+      <arg value="-Ddb.port=1530" />
+      <arg value="-Das.port=8083" />
+      <arg value="verify" />
+    </exec>
+    
+  </target>
+  
   
   <target name="set-version">
     

--- a/build.xml
+++ b/build.xml
@@ -141,9 +141,8 @@
       <env key="JAVA_HOME" value="${java.home}" />
       <arg value="-Dfile.encoding=UTF-8" />
       <arg value="-Das.port=8082" />
-      <arg value="derby:start" />
+      <arg value="-P${db}" />
       <arg value="site" />
-      <arg value="derby:stop" />
     </exec>
 
     <exec executable="${mvn.cmd}" dir="${workdir}/${testArtifactId}" failonerror="true">

--- a/javaee7-web-min/.settings/javaee7-web-min_20_wildfly-run.launch
+++ b/javaee7-web-min/.settings/javaee7-web-min_20_wildfly-run.launch
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.m2e.Maven2LaunchConfigurationType">
 <booleanAttribute key="M2_DEBUG_OUTPUT" value="false"/>
-<stringAttribute key="M2_GOALS" value="clean verify"/>
+<stringAttribute key="M2_GOALS" value="package wildfly:run"/>
 <booleanAttribute key="M2_NON_RECURSIVE" value="false"/>
 <booleanAttribute key="M2_OFFLINE" value="false"/>
-<stringAttribute key="M2_PROFILES" value="db-migrate,derby,wildfly,it"/>
+<stringAttribute key="M2_PROFILES" value="wildfly"/>
 <listAttribute key="M2_PROPERTIES"/>
 <stringAttribute key="M2_RUNTIME" value="EMBEDDED"/>
 <booleanAttribute key="M2_SKIP_TESTS" value="false"/>
@@ -13,11 +13,11 @@
 <stringAttribute key="M2_USER_SETTINGS" value=""/>
 <booleanAttribute key="M2_WORKSPACE_RESOLUTION" value="false"/>
 <mapAttribute key="org.eclipse.debug.core.environmentVariables">
-<mapEntry key="JBOSS_HOME" value="${workspace_loc:/javaee7-web-tips}/target/wildfly-run/wildfly-10.0.0.Final"/>
+<mapEntry key="JBOSS_HOME" value="${workspace_loc:/javaee7-web-min}/target/wildfly-run/wildfly-10.0.0.Final"/>
 </mapAttribute>
 <listAttribute key="org.eclipse.debug.ui.favoriteGroups">
 <listEntry value="org.eclipse.debug.ui.launchGroup.run"/>
 </listAttribute>
 <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
-<stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${workspace_loc:/javaee7-web-tips/}"/>
+<stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${workspace_loc:/javaee7-web-min}"/>
 </launchConfiguration>

--- a/javaee7-web-min/.settings/javaee7-web-tips_21_wildfly-stop.launch
+++ b/javaee7-web-min/.settings/javaee7-web-tips_21_wildfly-stop.launch
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.m2e.Maven2LaunchConfigurationType">
 <booleanAttribute key="M2_DEBUG_OUTPUT" value="false"/>
-<stringAttribute key="M2_GOALS" value="clean verify"/>
+<stringAttribute key="M2_GOALS" value="wildfly:shutdown"/>
 <booleanAttribute key="M2_NON_RECURSIVE" value="false"/>
 <booleanAttribute key="M2_OFFLINE" value="false"/>
-<stringAttribute key="M2_PROFILES" value="db-migrate,derby,wildfly,it"/>
+<stringAttribute key="M2_PROFILES" value="wildfly"/>
 <listAttribute key="M2_PROPERTIES"/>
 <stringAttribute key="M2_RUNTIME" value="EMBEDDED"/>
 <booleanAttribute key="M2_SKIP_TESTS" value="false"/>
@@ -13,11 +13,11 @@
 <stringAttribute key="M2_USER_SETTINGS" value=""/>
 <booleanAttribute key="M2_WORKSPACE_RESOLUTION" value="false"/>
 <mapAttribute key="org.eclipse.debug.core.environmentVariables">
-<mapEntry key="JBOSS_HOME" value="${workspace_loc:/javaee7-web-tips}/target/wildfly-run/wildfly-10.0.0.Final"/>
+<mapEntry key="JBOSS_HOME" value="${workspace_loc:/javaee7-web-min}/target/wildfly-run/wildfly-10.0.0.Final"/>
 </mapAttribute>
 <listAttribute key="org.eclipse.debug.ui.favoriteGroups">
 <listEntry value="org.eclipse.debug.ui.launchGroup.run"/>
 </listAttribute>
 <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
-<stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${workspace_loc:/javaee7-web-tips/}"/>
+<stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${workspace_loc:/javaee7-web-min}"/>
 </launchConfiguration>

--- a/javaee7-web-min/pom.xml
+++ b/javaee7-web-min/pom.xml
@@ -42,15 +42,45 @@
         <db.client.lib>${settings.localRepository}/com/ibm/db2/db2jcc/${db.client.version}</db.client.lib>
         <db.jdbc.driver>com.ibm.db2.jcc.DB2Driver</db.jdbc.driver>
         <db.jdbc.dsclass>com.ibm.db2.jcc.DB2ConnectionPoolDataSource</db.jdbc.dsclass>
-        <db.name>SAMPLE</db.name>
-        <db.host>localhost</db.host>
-        <db.port>50000</db.port>
+        <db.name>${db2.db.name}</db.name>
+        <db.host>${db2.db.host}</db.host>
+        <db.port>${db2.db.port}</db.port>
         <db.jdbc.url>jdbc:db2://${db.host}:${db.port}/${db.name}</db.jdbc.url>
-        <db.username>app</db.username>
-        <db.password>app</db.password>
+        <db.username>${db2.db.username}</db.username>
+        <db.password>${db2.db.password}</db.password>
         <db.flyway.comment>--</db.flyway.comment>
         <db.was-liberty.ds-properties><![CDATA[<properties.db2.jcc databaseName="${db.name}" serverName="${db.host}" portNumber="${db.port}" driverType="4" user="${db.username}" password="${db.password}"/>]]></db.was-liberty.ds-properties>
         <db.was-liberty.fileset><![CDATA[<fileset dir="${db.client.lib}" includes="db2jcc-${db.client.version}.jar"/>]]></db.was-liberty.fileset>
+        <db2.property.file>${toolsdir}/db2/db2-local.properties</db2.property.file>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>properties-maven-plugin</artifactId>
+            <version>1.0.0</version>
+            <executions>
+              <execution>
+                <phase>initialize</phase>
+                <goals>
+                  <goal>read-project-properties</goal>
+                </goals>
+                <configuration>
+                  <files>
+                    <file>${db2.property.file}</file>
+                  </files>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>sqldb-bluemix</id>
+      <properties>
+        <db2.property.file>${toolsdir}/db2/sqldb-bluemix.properties</db2.property.file>
       </properties>
     </profile>
 

--- a/javaee7-web-min/src/main/resources/META-INF/persistence.xml
+++ b/javaee7-web-min/src/main/resources/META-INF/persistence.xml
@@ -4,7 +4,7 @@
              http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd"
   version="2.1">
   <persistence-unit name="javaee7-web-min-pu">
-    <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
+    <provider>${jpa.provider}</provider>
     <jta-data-source>jdbc/javaee7-web-min-ds</jta-data-source>
     <properties>
       <property name="eclipselink.logging.logger" value="JavaLogger" />

--- a/javaee7-web-min/src/main/webapp/WEB-INF/beans.xml
+++ b/javaee7-web-min/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,6 @@
+ <beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+         http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+        bean-discovery-mode="all">
+ </beans>

--- a/javaee7-web-min/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/javaee7-web-min/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jboss-web xmlns="http://www.jboss.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.jboss.com/xml/ns/javaee http://www.jboss.org/j2ee/schema/jboss-web_10_0.xsd"
+  version="10.0">
+  
+  <context-root>/</context-root>
+
+</jboss-web>

--- a/javaee7-web-min/tools/cf/bluemix.properties
+++ b/javaee7-web-min/tools/cf/bluemix.properties
@@ -1,0 +1,10 @@
+### basics
+# append any suffix to cf.appname to avoid conflict of url.
+cf.appname=javaee7-web-min
+cf.target=(1)
+cf.org=(2)
+cf.space=(3)
+cf.username=(4)
+cf.password=(5)
+cf.instances=1
+cf.memory=512

--- a/javaee7-web-min/tools/db2/db2-local.properties
+++ b/javaee7-web-min/tools/db2/db2-local.properties
@@ -1,0 +1,6 @@
+### database
+db2.db.name=SAMPLE
+db2.db.host=localhost
+db2.db.port=50000
+db2.db.username=app
+db2.db.password=app

--- a/javaee7-web-min/tools/db2/sqldb-bluemix.properties
+++ b/javaee7-web-min/tools/db2/sqldb-bluemix.properties
@@ -1,0 +1,6 @@
+### database
+db2.db.name=(6)
+db2.db.host=(7)
+db2.db.port=(8)
+db2.db.username=(9)
+db2.db.password=(10)	

--- a/javaee7-web-min/tools/wildfly/build.xml
+++ b/javaee7-web-min/tools/wildfly/build.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="javaee7-web-tips-wildfly" basedir="../../" default="add-user">
+  
+  <property name="jboss.home" value="${basedir}/target/wildfly-run/wildfly-10.0.0.Final"/>
+  
+  <condition property="add-user" value="${jboss.home}/bin/add-user.bat" else="${jboss.home}/bin/add-user.sh">
+    <os family="windows"/>
+  </condition>
+  
+  <target name="add-user">
+
+    <exec executable="chmod">
+      <arg value="777" />
+      <arg value="${add-user}" />
+    </exec>
+
+    <exec executable="${add-user}">
+      <arg value="admin" />
+      <arg value="admin" />
+    </exec>
+
+  </target>
+
+
+</project>

--- a/javaee7-web-min/tools/wildfly/setup.cli
+++ b/javaee7-web-min/tools/wildfly/setup.cli
@@ -1,0 +1,10 @@
+connect
+
+module add --name=derby --resources=${db.client.lib}/${db.client.artifactId}-${db.client.version}.jar --dependencies=javax.api,javax.transaction.api
+
+/subsystem=datasources/jdbc-driver=derby:add(driver-name=derby,driver-module-name=derby)
+
+data-source add --jndi-name=java:/jdbc/${project.artifactId}-ds --name=${project.artifactId}-ds --connection-url=${db.jdbc.url} --driver-name=derby --user-name=${db.username} --password=${db.password}
+
+/subsystem=datasources:read-resource
+

--- a/javaee7-web-min/tools/wildfly/wildfly.properties
+++ b/javaee7-web-min/tools/wildfly/wildfly.properties
@@ -1,0 +1,1 @@
+jboss.http.port=${as.port}

--- a/javaee7-web-tips/.project
+++ b/javaee7-web-tips/.project
@@ -26,12 +26,12 @@
 			</arguments>
 		</buildCommand>
 		<buildCommand>
-			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<name>net.sf.eclipsecs.core.CheckstyleBuilder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>
 		<buildCommand>
-			<name>net.sf.eclipsecs.core.CheckstyleBuilder</name>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>

--- a/javaee7-web-tips/.settings/javaee7-web-tips_20_wildfly-run.launch
+++ b/javaee7-web-tips/.settings/javaee7-web-tips_20_wildfly-run.launch
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.m2e.Maven2LaunchConfigurationType">
 <booleanAttribute key="M2_DEBUG_OUTPUT" value="false"/>
-<stringAttribute key="M2_GOALS" value="clean verify"/>
+<stringAttribute key="M2_GOALS" value="package wildfly:run"/>
 <booleanAttribute key="M2_NON_RECURSIVE" value="false"/>
 <booleanAttribute key="M2_OFFLINE" value="false"/>
-<stringAttribute key="M2_PROFILES" value="db-migrate,derby,wildfly,it"/>
+<stringAttribute key="M2_PROFILES" value="wildfly"/>
 <listAttribute key="M2_PROPERTIES"/>
 <stringAttribute key="M2_RUNTIME" value="EMBEDDED"/>
 <booleanAttribute key="M2_SKIP_TESTS" value="false"/>
@@ -19,5 +19,5 @@
 <listEntry value="org.eclipse.debug.ui.launchGroup.run"/>
 </listAttribute>
 <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
-<stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${workspace_loc:/javaee7-web-tips/}"/>
+<stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${workspace_loc:/javaee7-web-tips}"/>
 </launchConfiguration>

--- a/javaee7-web-tips/.settings/javaee7-web-tips_21_wildfly-stop.launch
+++ b/javaee7-web-tips/.settings/javaee7-web-tips_21_wildfly-stop.launch
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.m2e.Maven2LaunchConfigurationType">
 <booleanAttribute key="M2_DEBUG_OUTPUT" value="false"/>
-<stringAttribute key="M2_GOALS" value="clean verify"/>
+<stringAttribute key="M2_GOALS" value="wildfly:shutdown"/>
 <booleanAttribute key="M2_NON_RECURSIVE" value="false"/>
 <booleanAttribute key="M2_OFFLINE" value="false"/>
-<stringAttribute key="M2_PROFILES" value="db-migrate,derby,wildfly,it"/>
+<stringAttribute key="M2_PROFILES" value="wildfly"/>
 <listAttribute key="M2_PROPERTIES"/>
 <stringAttribute key="M2_RUNTIME" value="EMBEDDED"/>
 <booleanAttribute key="M2_SKIP_TESTS" value="false"/>
@@ -19,5 +19,5 @@
 <listEntry value="org.eclipse.debug.ui.launchGroup.run"/>
 </listAttribute>
 <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
-<stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${workspace_loc:/javaee7-web-tips/}"/>
+<stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${workspace_loc:/javaee7-web-tips}"/>
 </launchConfiguration>

--- a/javaee7-web-tips/.settings/org.eclipse.core.resources.prefs
+++ b/javaee7-web-tips/.settings/org.eclipse.core.resources.prefs
@@ -6,4 +6,5 @@ encoding//src/test/java=UTF-8
 encoding//src/test/resources=UTF-8
 encoding//tools/hibernate-tools=UTF-8
 encoding//tools/hibernate-tools/src=UTF-8
+encoding//tools/wildfly=UTF-8
 encoding/<project>=UTF-8

--- a/javaee7-web-tips/.settings/org.eclipse.jpt.core.prefs
+++ b/javaee7-web-tips/.settings/org.eclipse.jpt.core.prefs
@@ -1,3 +1,3 @@
 eclipse.preferences.version=1
-org.eclipse.jpt.core.platform=eclipselink2_5
+org.eclipse.jpt.core.platform=generic2_1
 org.eclipse.jpt.jpa.core.discoverAnnotatedClasses=true

--- a/javaee7-web-tips/.settings/org.eclipse.wst.common.project.facet.core.prefs.xml
+++ b/javaee7-web-tips/.settings/org.eclipse.wst.common.project.facet.core.prefs.xml
@@ -4,4 +4,14 @@
       <attribute name="provider-id" value="jsf-user-library-provider"/>
     </node>
   </facet>
+  <facet id="jpt.jpa">
+    <node name="libprov">
+      <attribute name="provider-id" value="jpa-no-op-library-provider"/>
+    </node>
+  </facet>
+  <facet id="jst.jaxrs">
+    <node name="libprov">
+      <attribute name="provider-id" value="jaxrs-no-op-library-provider"/>
+    </node>
+  </facet>
 </root>

--- a/javaee7-web-tips/.settings/org.eclipse.wst.common.project.facet.core.xml
+++ b/javaee7-web-tips/.settings/org.eclipse.wst.common.project.facet.core.xml
@@ -5,4 +5,6 @@
   <installed facet="java" version="1.8"/>
   <installed facet="jst.web" version="3.1"/>
   <installed facet="jst.jsf" version="2.2"/>
+  <installed facet="jpt.jpa" version="2.1"/>
+  <installed facet="jst.jaxrs" version="2.0"/>
 </faceted-project>

--- a/javaee7-web-tips/src/main/java/org/sitoolkit/ad/archetype/tips/infrastructure/data/jpa/BaseEntityListener.java
+++ b/javaee7-web-tips/src/main/java/org/sitoolkit/ad/archetype/tips/infrastructure/data/jpa/BaseEntityListener.java
@@ -3,13 +3,18 @@ package org.sitoolkit.ad.archetype.tips.infrastructure.data.jpa;
 import java.security.Principal;
 import java.sql.Timestamp;
 
-import javax.inject.Inject;
 import javax.persistence.PrePersist;
 import javax.persistence.PreUpdate;
 
 public class BaseEntityListener {
 
-    @Inject
+    /*
+     * TODO JPA 2.1からEntityListenerにCDIが有効になる仕様が追加されていますが、 Wildfly
+     * 10.0.0.Finalでは org.jboss.weld.exceptions.IllegalArgumentException:
+     * WELD-001456: Argument resolvedBean must not be null 例外が送出されます。
+     * https://issues.jboss.org/browse/WFLY-2540 一旦コメントアウトします。
+     */
+    // @Inject
     Principal principal;
 
     /**

--- a/javaee7-web-tips/src/main/java/org/sitoolkit/ad/archetype/tips/infrastructure/data/jpa/BaseRepository.java
+++ b/javaee7-web-tips/src/main/java/org/sitoolkit/ad/archetype/tips/infrastructure/data/jpa/BaseRepository.java
@@ -14,7 +14,8 @@ import org.sitoolkit.ad.archetype.tips.infrastructure.search.SearchConditionDo;
  *
  * @author SIToolkit
  */
-public abstract class BaseRepository<E extends BaseEntity, I extends Serializable> implements Serializable {
+public abstract class BaseRepository<E extends BaseEntity, I extends Serializable>
+        implements Serializable {
 
     /**
      * 

--- a/javaee7-web-tips/src/main/resources/META-INF/persistence.xml
+++ b/javaee7-web-tips/src/main/resources/META-INF/persistence.xml
@@ -4,7 +4,7 @@
              http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd"
   version="2.1">
   <persistence-unit name="javaee7-web-tips-pu" transaction-type="JTA">
-    <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
+    <provider>${jpa.provider}</provider>
     <jta-data-source>jdbc/javaee7-web-tips-ds</jta-data-source>
     <properties>
       <property name="eclipselink.logging.logger" value="JavaLogger" />

--- a/javaee7-web-tips/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/javaee7-web-tips/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jboss-web xmlns="http://www.jboss.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.jboss.com/xml/ns/javaee http://www.jboss.org/j2ee/schema/jboss-web_10_0.xsd"
+  version="10.0">
+  
+  <context-root>/</context-root>
+  <security-domain>other</security-domain>
+
+</jboss-web>

--- a/javaee7-web-tips/src/main/webapp/WEB-INF/web.xml
+++ b/javaee7-web-tips/src/main/webapp/WEB-INF/web.xml
@@ -45,7 +45,8 @@
     <res-type>javax.sql.DataSource</res-type>
     <res-auth>Container</res-auth>
     <res-sharing-scope>Shareable</res-sharing-scope>
-    <lookup-name>java:module/env/jdbc/javaee7-web-tips-ds</lookup-name>
+<!--     <lookup-name>java:module/env/jdbc/javaee7-web-tips-ds</lookup-name> -->
+    <lookup-name>java:/jdbc/javaee7-web-tips-ds</lookup-name>
   </resource-ref>
 
   <security-role>
@@ -58,7 +59,7 @@
   </security-role>
   <security-constraint>
     <web-resource-collection>
-      <web-resource-name>pages for both users and admins</web-resource-name>
+      <web-resource-name>pages for only admins</web-resource-name>
       <url-pattern>/pages/management/*</url-pattern>
     </web-resource-collection>
     <auth-constraint>
@@ -67,7 +68,7 @@
   </security-constraint>
   <security-constraint>
     <web-resource-collection>
-      <web-resource-name>pages for only admins</web-resource-name>
+      <web-resource-name>pages for both users and admins</web-resource-name>
       <url-pattern>/pages/*</url-pattern>
     </web-resource-collection>
     <auth-constraint>

--- a/javaee7-web-tips/tools/wildfly/build.xml
+++ b/javaee7-web-tips/tools/wildfly/build.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="javaee7-web-tips-wildfly" basedir="../../" default="add-user">
+  
+  <property name="jboss.home" value="${basedir}/target/wildfly-run/wildfly-10.0.0.Final"/>
+  
+  <condition property="add-user" value="${jboss.home}/bin/add-user.bat" else="${jboss.home}/bin/add-user.sh">
+    <os family="windows"/>
+  </condition>
+  
+  <target name="add-user">
+
+    <exec executable="chmod">
+      <arg value="777" />
+      <arg value="${add-user}" />
+    </exec>
+
+    <exec executable="${add-user}">
+      <arg value="admin" />
+      <arg value="admin" />
+    </exec>
+
+    <exec executable="${add-user}">
+      <arg value="-a" />
+      <arg value="admin" />
+      <arg value="sitoolkit1" />
+    </exec>
+
+    <exec executable="${add-user}">
+      <arg value="-a" />
+      <arg value="user" />
+      <arg value="sitoolkit1" />
+    </exec>
+
+    <concat append="true" destfile="${jboss.home}/standalone/configuration/application-roles.properties">admin=admin</concat>
+  </target>
+
+
+</project>

--- a/javaee7-web-tips/tools/wildfly/setup.cli
+++ b/javaee7-web-tips/tools/wildfly/setup.cli
@@ -1,0 +1,16 @@
+connect
+
+module add --name=derby --resources=${db.client.lib}/${db.client.artifactId}-${db.client.version}.jar --dependencies=javax.api,javax.transaction.api
+
+/subsystem=datasources/jdbc-driver=derby:add(driver-name=derby,driver-module-name=derby)
+
+data-source add --jndi-name=java:/jdbc/${project.artifactId}-ds --name=${project.artifactId}-ds --connection-url=${db.jdbc.url} --driver-name=derby --user-name=${db.username} --password=${db.password}
+
+/subsystem=datasources:read-resource
+
+
+# https://docs.jboss.org/author/display/WFLY10/How+To
+
+# /subsystem=logging/logger=org.jboss.security:add
+# /subsystem=logging/console-handler=CONSOLE:write-attribute(name=level,value=TRACE)
+# /subsystem=logging/logger=org.jboss.security:write-attribute(name=level,value=TRACE)

--- a/javaee7-web-tips/tools/wildfly/wildfly.properties
+++ b/javaee7-web-tips/tools/wildfly/wildfly.properties
@@ -1,0 +1,1 @@
+jboss.http.port=${as.port}

--- a/pom.xml
+++ b/pom.xml
@@ -574,7 +574,7 @@
               <assemblyArtifact>
                 <groupId>com.ibm.websphere.appserver.runtime</groupId>
                 <artifactId>wlp-javaee7</artifactId>
-                <version>8.5.5.8</version>
+                <version>8.5.5.9</version>
                 <type>zip</type>
               </assemblyArtifact>
               <configFile>${project.build.directory}/server.xml</configFile>
@@ -764,6 +764,92 @@
                   <goal>integration-test</goal>
                   <goal>verify</goal>
                 </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>bluemix</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.cloudfoundry</groupId>
+            <artifactId>cf-maven-plugin</artifactId>
+            <version>1.1.2</version>
+            <configuration>
+              <target>${cf.target}</target>
+              <appname>${cf.appname}</appname>
+              <org>${cf.org}</org>
+              <space>${cf.space}</space>
+              <username>${cf.username}</username>
+              <password>${cf.password}</password>
+              <instances>${cf.instances}</instances>
+              <memory>${cf.memory}</memory>
+              <services>
+                <!-- Add services you want to create and bind here -->
+                <service>
+                  <name>javaee7-web-min-ds</name>
+                  <label>sqldb</label>
+                  <plan>sqldb_free</plan>
+                </service>
+              </services>
+              <env>
+                <!-- Set any environment variables -->
+                <!--
+                <myvar>myvalue</myvar>
+                -->
+              </env>
+            </configuration>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <goals>
+                  <goal>push</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>properties-maven-plugin</artifactId>
+            <version>1.0.0</version>
+            <executions>
+              <execution>
+                <phase>initialize</phase>
+                <goals>
+                  <goal>read-project-properties</goal>
+                </goals>
+                <configuration>
+                  <files>
+                    <file>${toolsdir}/cf/bluemix.properties</file>
+                  </files>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>skip-compile</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>default-compile</id>
+                <phase>compile</phase>
+                <goals>
+                  <goal>compile</goal>
+                </goals>
+                <configuration>
+                  <skipMain>true</skipMain>
+                </configuration>
               </execution>
             </executions>
           </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,7 @@
     <hibernate-tools.destdir>${project.build.directory}/generated-sources/hibernate-tools</hibernate-tools.destdir>
     <payara.version>4.1.153</payara.version>
     <deltaspike.version>1.5.4</deltaspike.version>
+    <skipUTs>false</skipUTs>
   </properties>
 
   <!-- Build Settings -->
@@ -190,6 +191,14 @@
               <version>${db.client.version}</version>
             </dependency>
           </dependencies>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.19.1</version>
+          <configuration>
+            <skipTests>${skipUTs}</skipTests>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.sonarsource.scanner.maven</groupId>
@@ -352,7 +361,7 @@
             <artifactId>derby-maven-plugin</artifactId>
             <executions>
               <execution>
-                <id>start</id>
+                <id>start-on-initialize</id>
                 <phase>initialize</phase>
                 <goals>
                   <goal>start</goal>
@@ -361,6 +370,20 @@
               <execution>
                 <id>stop-on-post-integration-test</id>
                 <phase>post-integration-test</phase>
+                <goals>
+                  <goal>stop</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>start-on-presite</id>
+                <phase>pre-site</phase>
+                <goals>
+                  <goal>start</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>stop-on-post-site</id>
+                <phase>post-site-test</phase>
                 <goals>
                   <goal>stop</goal>
                 </goals>
@@ -620,6 +643,7 @@
       </dependencies>
       <properties>
         <maven.test.skip>false</maven.test.skip>
+        <skipUTs>true</skipUTs>
         <sitwt.version>0.11.1</sitwt.version>
       </properties>
       <build>

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,7 @@
     <hibernate-tools.destdir>${project.build.directory}/generated-sources/hibernate-tools</hibernate-tools.destdir>
     <payara.version>4.1.153</payara.version>
     <deltaspike.version>1.5.4</deltaspike.version>
+    <jpa.provider>org.eclipse.persistence.jpa.PersistenceProvider</jpa.provider>
     <skipUTs>false</skipUTs>
   </properties>
 
@@ -115,6 +116,13 @@
     <resources>
       <resource>
         <directory>src/main/resources</directory>
+      </resource>
+      <resource>
+        <directory>src/main/resources</directory>
+        <includes>
+          <include>META-INF/persistence.xml</include>
+        </includes>
+        <filtering>true</filtering>
       </resource>
       <resource>
         <directory>src/main/webapp</directory>
@@ -163,34 +171,10 @@
             </dependency>
           </dependencies>
         </plugin>
-        <!-- Hibernate Tools -->
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-antrun-plugin</artifactId>
           <version>1.8</version>
-          <configuration>
-            <target>
-              <property name="maven.classpath" refid="maven.plugin.classpath" />
-              <ant antfile="${hibernate-tools.basedir}/build.xml" />
-            </target>
-          </configuration>
-          <dependencies>
-            <dependency>
-              <groupId>org.apache.ant</groupId>
-              <artifactId>ant</artifactId>
-              <version>1.9.6</version>
-            </dependency>
-            <dependency>
-              <groupId>org.hibernate</groupId>
-              <artifactId>hibernate-tools</artifactId>
-              <version>4.3.1.Final</version>
-            </dependency>
-            <dependency>
-              <groupId>${db.client.groupId}</groupId>
-              <artifactId>${db.client.artifactId}</artifactId>
-              <version>${db.client.version}</version>
-            </dependency>
-          </dependencies>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -414,12 +398,37 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-antrun-plugin</artifactId>
+            <dependencies>
+              <dependency>
+                <groupId>org.hibernate</groupId>
+                <artifactId>hibernate-tools</artifactId>
+                <version>4.3.2.Final</version>
+                <exclusions>
+                  <exclusion>
+                    <groupId>ant</groupId>
+                    <artifactId>ant</artifactId>
+                  </exclusion>
+                </exclusions>
+              </dependency>
+              <dependency>
+                <groupId>${db.client.groupId}</groupId>
+                <artifactId>${db.client.artifactId}</artifactId>
+                <version>${db.client.version}</version>
+              </dependency>
+            </dependencies>
             <executions>
               <execution>
+                <id>run-hibernate-tools</id>
                 <phase>generate-sources</phase>
                 <goals>
                   <goal>run</goal>
                 </goals>
+                <configuration>
+                  <target>
+                    <property name="maven.classpath" refid="maven.plugin.classpath" />
+                    <ant antfile="${hibernate-tools.basedir}/build.xml" />
+                  </target>
+                </configuration>
               </execution>
             </executions>
           </plugin>
@@ -629,6 +638,79 @@
           </releases>
         </pluginRepository>
       </pluginRepositories>
+    </profile>
+
+    <profile>
+      <id>wildfly</id>
+      <properties>
+        <maven.test.skip>true</maven.test.skip>
+        <jpa.provider>org.hibernate.ejb.HibernatePersistence</jpa.provider>
+      </properties>
+      <build>
+        <defaultGoal>package wildfly:run</defaultGoal>
+        <resources>
+          <resource>
+            <directory>${toolsdir}/wildfly</directory>
+            <includes>
+              <include>setup.cli</include>
+              <include>wildfly.properties</include>
+            </includes>
+            <filtering>true</filtering>
+            <targetPath>${project.build.directory}</targetPath>
+          </resource>
+        </resources>
+        <plugins>
+          <plugin>
+            <groupId>org.wildfly.plugins</groupId>
+            <artifactId>wildfly-maven-plugin</artifactId>
+            <version>1.0.2.Final</version>
+            <configuration>
+              <propertiesFile>${project.build.directory}/wildfly.properties</propertiesFile>
+              <beforeDeployment>
+                <batch>false</batch>
+                <scripts>
+                  <script>${project.build.directory}/setup.cli</script>
+                </scripts>
+              </beforeDeployment>
+            </configuration>
+            <executions>
+              <execution>
+                <id>start-server</id>
+                <phase>pre-integration-test</phase>
+                <goals>
+                  <goal>start</goal>
+                  <goal>deploy</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>stop-server</id>
+                <phase>post-integration-test</phase>
+                <goals>
+                  <goal>shutdown</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>run-wildfly-settings</id>
+                <phase>pre-integration-test</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                  <configuration>
+                    <target>
+                      <ant antfile="${toolsdir}/wildfly/build.xml" />
+                    </target>
+                  </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
 
     <profile>


### PR DESCRIPTION
Issue、使用方法は下記をご覧ください。

[Issue] Bluemixサポート追加 #10 
[使い方] SIT AD Bluemixサポートの利用方法
https://github.com/hfujikawa77/sit-ad-archetype-javaee7-web/wiki/SIT-AD-Bluemix%E3%82%B5%E3%83%9D%E3%83%BC%E3%83%88%E3%81%AE%E5%88%A9%E7%94%A8%E6%96%B9%E6%B3%95

他考慮点など
- cf:push はコンパイルが必ず走ってしまうため、仮プッシュ用にはcompileプラグイを動作させないskip-compileプロファイルを作って対応しました。
- 将来的にBluemix以外のCloudFoundryベースPaaSに対応する可能性も考えられるのでBluemix非依存箇所は「cf.」としています。例) cf.appname
- Bluemix上SQLDBの中身はDB2なので、DB2用プロファイル(db2)を共用し環境依存部分のみ追加プロファイル(sqldb-bluemix)で対応するアプローチとしました。

以上
